### PR TITLE
ci: Renovateの更新時にcloud_firestoreとfirebase_coreは同時にアップデートするように修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
       "automerge": true
     },
     {
+      "matchPackageNames": ["cloud_firestore", "firebase_core"],
+      "groupName": "cloud_firestore"
+    },
+    {
       "matchManagers": ["pub"],
       "addLabels": ["dart"],
       "automerge": true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added configuration for `cloud_firestore` and `firebase_core` packages to the `renovate.json` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->