### PR TITLE
feat: メッセージ投稿画面の右上にプロフィールを表示

### DIFF
--- a/lib/ui/post_message_screen.dart
+++ b/lib/ui/post_message_screen.dart
@@ -57,7 +57,7 @@ class _PostMessageScreenState extends ConsumerState<PostMessageScreen> {
         child: Column(
           children: [
             Align(
-              alignment: Alignment.topRight,
+              alignment: Alignment.centerRight,
               child: _ProfilePanel(),
             ),
             const SizedBox(height: 8),

--- a/lib/ui/post_message_screen.dart
+++ b/lib/ui/post_message_screen.dart
@@ -58,7 +58,7 @@ class _PostMessageScreenState extends ConsumerState<PostMessageScreen> {
           children: [
             Align(
               alignment: Alignment.topRight,
-              child: _ProfileDisplay(),
+              child: _ProfilePanel(),
             ),
             const SizedBox(height: 8),
             TextField(
@@ -146,7 +146,7 @@ class _PostMessageScreenState extends ConsumerState<PostMessageScreen> {
   }
 }
 
-class _ProfileDisplay extends ConsumerWidget {
+class _ProfilePanel extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profile = ref.watch(profileProvider);

--- a/lib/ui/post_message_screen.dart
+++ b/lib/ui/post_message_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isekai/data/model/profile.dart';
+import 'package:isekai/data/repository/preference_repository.dart';
 import 'package:isekai/data/usecase/message_use_case.dart';
 import 'package:isekai/data/usecase/preference_use_case.dart';
 import 'package:isekai/ui/model/confirm_result_with_do_not_show_again_option.dart';
@@ -55,6 +56,11 @@ class _PostMessageScreenState extends ConsumerState<PostMessageScreen> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
+            Align(
+              alignment: Alignment.topRight,
+              child: _ProfileDisplay(),
+            ),
+            const SizedBox(height: 8),
             TextField(
               controller: _controller,
               autofocus: true,
@@ -136,6 +142,23 @@ class _PostMessageScreenState extends ConsumerState<PostMessageScreen> {
           },
         );
       },
+    );
+  }
+}
+
+class _ProfileDisplay extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(profileProvider);
+    if (profile == null) {
+      return const CircularProgressIndicator();
+    }
+
+    return Column(
+      children: [
+        Text(profile.icon, style: Theme.of(context).textTheme.headlineSmall),
+        Text(profile.name, style: Theme.of(context).textTheme.bodySmall),
+      ],
     );
   }
 }

--- a/lib/ui/post_message_screen.dart
+++ b/lib/ui/post_message_screen.dart
@@ -154,9 +154,11 @@ class _ProfileDisplay extends ConsumerWidget {
       return const CircularProgressIndicator();
     }
 
-    return Column(
+    return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Text(profile.icon, style: Theme.of(context).textTheme.headlineSmall),
+        Text(profile.icon, style: Theme.of(context).textTheme.bodySmall),
+        const SizedBox(width: 8),
         Text(profile.name, style: Theme.of(context).textTheme.bodySmall),
       ],
     );


### PR DESCRIPTION
Fixes #498

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rainbeek/isekai/pull/499?shareId=a7be7c30-5baa-470b-a195-f5ce75dfe8ad).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new profile display widget on the Post Message screen, showing user information at the top right.
	- Added a loading indicator for cases when profile data is not yet available.

- **Enhancements**
	- Improved user interface by integrating profile information seamlessly into the existing layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->