### PR TITLE
ci: SDKでピン留めされているDartのライブラリをRenovateでは無視するように設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,11 @@
     },
     {
       "matchManagers": ["pub"],
+      "matchPackageNames": ["collection", "dart", "intl", "path"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pub"],
       "addLabels": ["dart"],
       "automerge": true
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management configuration to prevent automatic updates for specific Dart packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->